### PR TITLE
Allow loading an initial drawing of more than 32768 lines

### DIFF
--- a/remote_drawing_wifi/redis_client.h
+++ b/remote_drawing_wifi/redis_client.h
@@ -39,7 +39,7 @@ void redisPlanClearDrawing();
 // Download the drawing lines in interval [start, stop].
 // Pass [0,-1] to get all lines.
 // Call redisDownloadLine() to then get each line
-int redisDownloadLinesBegin(int start, int stop);
+long redisDownloadLinesBegin(long start, long stop);
 
 // To call after redisDownloadLinesStart(),
 // as many times as the value redisDownloadLinesStart() returned.

--- a/remote_drawing_wifi/redis_client.ino
+++ b/remote_drawing_wifi/redis_client.ino
@@ -101,11 +101,11 @@ int expectRedisInteger(WiFiClient *client, const char *command) {
   }
 }
 
-int expectRedisArrayCount(WiFiClient *client, const char *command) {
+long expectRedisArrayCount(WiFiClient *client, const char *command) {
   char buf[REDIS_RECEIVE_BUFFER_SIZE];
   redisReceive(client, buf, command);
   if (buf[0] == '*') {
-    return atoi(buf + 1);
+    return atol(buf + 1);
   } else {
     fatalError("Expected array count for %s but got: \"%s\"", command, buf);
     return 0; // never reached, as fatalError() never returns
@@ -229,11 +229,11 @@ int redisBatchRPUSH(const char *key, byte buf[], int elementSize, int numberOfEl
 // Execute the Redis LRANGE command.
 // Returns the number of elements in the array
 // You should then read them with redisReadArrayElement()
-int redisLRANGE(const char *key, int start, int stop) {
-  char startAsString[10];
-  char stopAsString[10];
-  snprintf(startAsString, 10, "%d", start);
-  snprintf(stopAsString, 10, "%d", stop);
+long redisLRANGE(const char *key, long start, long stop) {
+  char startAsString[12];
+  char stopAsString[12];
+  snprintf(startAsString, 12, "%ld", start);
+  snprintf(stopAsString, 12, "%ld", stop);
 
   mainClient.write("*4\r\n");
   mainClient.write("$6\r\n");
@@ -426,7 +426,7 @@ void redisPingSubClient() {
   }
 }
 
-int redisDownloadLinesBegin(int start, int stop) {
+long redisDownloadLinesBegin(long start, long stop) {
   return redisLRANGE(REDIS_LINES_KEY, start, stop);
 }
 

--- a/remote_drawing_wifi/remote_drawing_wifi.ino
+++ b/remote_drawing_wifi/remote_drawing_wifi.ino
@@ -132,10 +132,10 @@ void handleRedisReceive() {
   }
 }
 
-void getLinesFromRedisAndDrawThem(int count) {
+void getLinesFromRedisAndDrawThem(long count) {
   Line line;
 
-  for (int i = 0; i < count; i++) {
+  for (long i = 0; i < count; i++) {
     // Receive line from Redis
     redisDownloadLine(&line);
     // Send line to UX Arduino to render it on screen
@@ -144,14 +144,14 @@ void getLinesFromRedisAndDrawThem(int count) {
 }
 
 void downloadInitialData() {
-  int count;
+  long count;
 
   sendStatusMessage("Downloading drawing from server...");
   count = redisDownloadLinesBegin(0, -1);
 
-  sendStatusMessageFormat("Downloading drawing from server (%d lines). Please wait...", count);
+  sendStatusMessageFormat("Downloading drawing from server (%ld lines). Please wait...", count);
   getLinesFromRedisAndDrawThem(count);
-  sendStatusMessageFormat("Downloaded %d lines. You can now draw!", count);
+  sendStatusMessageFormat("Downloaded %ld lines. You can now draw!", count);
 }
 
 void loop() {

--- a/remote_drawing_wifi/system.h
+++ b/remote_drawing_wifi/system.h
@@ -2,7 +2,7 @@
 #define SYSTEM_H
 
 // Version of Wifi Arduino code
-#define VERSION "1.1"
+#define VERSION "1.2"
 
 // Pin tied to the other ("UX") Arduino reset circuit
 #define PIN_TO_OTHER_ARDUINO_RESET_CIRCUIT 7

--- a/remote_drawing_wifi/system.h
+++ b/remote_drawing_wifi/system.h
@@ -2,7 +2,7 @@
 #define SYSTEM_H
 
 // Version of Wifi Arduino code
-#define VERSION "1.1"
+#define VERSION "2.0"
 
 // Pin tied to the other ("UX") Arduino reset circuit
 #define PIN_TO_OTHER_ARDUINO_RESET_CIRCUIT 7

--- a/remote_drawing_wifi/system.h
+++ b/remote_drawing_wifi/system.h
@@ -2,7 +2,7 @@
 #define SYSTEM_H
 
 // Version of Wifi Arduino code
-#define VERSION "2.0"
+#define VERSION "1.1"
 
 // Pin tied to the other ("UX") Arduino reset circuit
 #define PIN_TO_OTHER_ARDUINO_RESET_CIRCUIT 7


### PR DESCRIPTION
This is one part of a fix for https://github.com/raphaelchampeimont/arduino_remote_drawing/issues/7.

This fixes only the part about re-loading the entire drawing on reboot if the drawing is more than 32768 lines. The good thing is, this part of the fix does not break protocol compatibility between the two stations (which is why we change the minor version number only).

It does not fix the part of the bug about drawing the lines >32768 and them being displayed incorrectly on the other side in real time. This will come in another PR with the protocol-breaking change.